### PR TITLE
Removed explicit dependency to logging plugin so people can change the logging framework

### DIFF
--- a/CacheHeadersGrailsPlugin.groovy
+++ b/CacheHeadersGrailsPlugin.groovy
@@ -4,7 +4,7 @@ import groovy.util.ConfigObject
 class CacheHeadersGrailsPlugin {
     def version = "1.1.5"
     def grailsVersion = "1.2.0 > *"
-    def dependsOn = ['controllers':'1.1 > *', 'logging':'1.1 > *']
+    def dependsOn = ['controllers':'1.1 > *']
     def pluginExcludes = [
             "grails-app/views/error.gsp",
             "grails-app/controllers/**"


### PR DESCRIPTION
When following the instructions in the Grails guide (http://grails.org/doc/2.0.x/guide/conf.html#logging), run-app fails because of that explicit dependency.

To reproduce, add to an app using the cache-headers plugin:
    ...
    inherits("global") {
      excludes "grails-plugin-logging", "log4j"
    }
    …

and then grails run-app
