### PR TITLE
A couple of cleanup commits

### DIFF
--- a/CacheHeadersGrailsPlugin.groovy
+++ b/CacheHeadersGrailsPlugin.groovy
@@ -4,7 +4,7 @@ import groovy.util.ConfigObject
 class CacheHeadersGrailsPlugin {
     def version = "1.1.5"
     def grailsVersion = "1.2.0 > *"
-    def dependsOn = ['controllers':'1.1 > *', 'logging':'1.1 > *']
+    def dependsOn = ['controllers':'1.1 > *']
     def pluginExcludes = [
             "grails-app/views/error.gsp",
             "grails-app/controllers/**"

--- a/application.properties
+++ b/application.properties
@@ -2,5 +2,3 @@
 #Thu Apr 21 12:23:02 BST 2011
 app.grails.version=1.3.7
 app.name=CacheHeaders
-plugins.hibernate=1.3.7
-plugins.tomcat=1.3.7


### PR DESCRIPTION
@marcpalmer here's some commits that do a few (very minor) cleanups to the grails-cache-headers plugin.
- Remove direct dependency on "logging" core plugin - this was causing issues for us when switching away from the default Grails logging implementation, as it brings in the log4j binding for slf4j.
- Removed tomcat/hibernate dependencies from application.properties - they're not needed for the plugin and thus shouldn't bring transitive baggage into projects that use grails-cache-headers plugin.
- Checked in grails-app/conf/.empty, as empty directories don't get staged in git index, but grails test-app freaks out if the conf directory doesn't exist.

Let me know if you have any queries!
